### PR TITLE
Corrected issue where dropzone is highlighted when a draggable element begins drag.

### DIFF
--- a/css/dragquestion.css
+++ b/css/dragquestion.css
@@ -181,8 +181,7 @@ html.h5p-iframe .h5p-container.h5p-dragquestion.h5p-semi-fullscreen {
 }
 
 .h5p-dragquestion .h5p-dropzone > .h5p-inner.h5p-active {
-  padding: 0;
-  border: 0.1em dashed #666;
+
 }
 
 .h5p-dragquestion .h5p-dropzone > .h5p-inner.h5p-over {


### PR DESCRIPTION
Corrected issue where dropzone is highlighted when a draggable element begins drag which gives away the answer.